### PR TITLE
Allow required UUID type in scaffold.

### DIFF
--- a/src/gen/scaffold.rs
+++ b/src/gen/scaffold.rs
@@ -25,6 +25,7 @@ lazy_static! {
         ("ts", "Option<DateTime>"),
         ("ts!", "DateTime"),
         ("uuid", "Option<Uuid>"),
+        ("uuid!", "Uuid"),        
         ("json", "Option<serde_json::Value>"),
         ("json!", "serde_json::Value"),
         ("jsonb", "Option<serde_json::Value>"),


### PR DESCRIPTION
Allow scaffolding to create a required UUID.